### PR TITLE
[Debugging] Do not fallback to slow_backtrace when tdep_trace stops unwinding

### DIFF
--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -432,7 +432,10 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
   sp = cfa = d->cfa;
   ACCESS_MEM_FAST(ret, 0, d, DWARF_GET_LOC(d->loc[UNW_AARCH64_X29]), fp);
   assert(ret == 0);
-  lr = 0;
+
+  /* In case of unwinding from ucontext_t, we can look at the link
+     register value */
+  ACCESS_MEM_FAST(ret, 0, d, DWARF_GET_LOC(d->loc[UNW_AARCH64_X30]), lr);
 
   /* Get frame cache. */
   if (unlikely(! (cache = trace_cache_get())))
@@ -450,8 +453,8 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
   while (depth < maxdepth)
   {
     pc -= d->use_prev_instr;
-    Debug (2, "depth %d cfa 0x%lx pc 0x%lx sp 0x%lx fp 0x%lx\n",
-           depth, cfa, pc, sp, fp);
+    Debug (2, "depth %d cfa 0x%lx pc 0x%lx sp 0x%lx fp 0x%lx, lr 0x%lx\n",
+           depth, cfa, pc, sp, fp, lr);
 
     /* See if we have this address cached.  If not, evaluate enough of
        the dwarf unwind information to fill the cache line data, or to
@@ -501,6 +504,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       else if (lr != 0)
         {
           /* Use the saved link register as the new pc. */
+          Debug(4, "use link register value 0x%lx as the new pc\n", lr);
           pc = lr;
           lr = 0;
         }
@@ -537,6 +541,9 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       if (likely(ret >= 0))
         ACCESS_MEM_FAST(ret, c->validate, d, cfa + SC_X30_OFF, lr);
 
+      Debug(4, "signal frame cfa 0x%lx pc 0x%lx fp 0x%lx sp 0x%lx lr 0x%lx\n",
+            cfa, pc, fp, sp, lr);
+
       /* Resume stack at signal restoration point. The stack is not
          necessarily continuous here, especially with sigaltstack(). */
       cfa = sp;
@@ -554,8 +561,8 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       return -UNW_ESTOPUNWIND;
     }
 
-    Debug (4, "new cfa 0x%lx pc 0x%lx sp 0x%lx fp 0x%lx\n",
-           cfa, pc, sp, fp);
+    Debug (4, "new cfa 0x%lx pc 0x%lx sp 0x%lx fp 0x%lx lr 0x%lx\n",
+           cfa, pc, sp, fp, lr);
 
     /* If we failed or ended up somewhere bogus, stop. */
     if (unlikely(ret < 0 || pc < 0x4000))

--- a/src/mi/backtrace.c
+++ b/src/mi/backtrace.c
@@ -67,7 +67,8 @@ unw_backtrace (void **buffer, int size)
   if (unlikely (unw_init_local (&cursor, &uc) < 0))
     return 0;
 
-  if (unlikely (tdep_trace (&cursor, buffer, &n) < 0))
+  int ret = tdep_trace (&cursor, buffer, &n);
+  if (unlikely (ret < 0 && ret != -UNW_ESTOPUNWIND))
     {
       unw_getcontext (&uc);
       return slow_backtrace (buffer, size, &uc, 0);
@@ -108,7 +109,8 @@ unw_backtrace2 (void **buffer, int size, unw_context_t* uc2, int flag)
 
   // returns the number of frames collected by tdep_trace or slow_backtrace
   // and add 1 to it (the one we retrieved above)
-  if (unlikely (tdep_trace (&cursor, buffer, &n) < 0))
+  int ret = tdep_trace (&cursor, buffer, &n);
+  if (unlikely (ret < 0 && ret != -UNW_ESTOPUNWIND))
     {
       return slow_backtrace (buffer, remaining_size, &uc, flag) + 1;
     }

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -56,8 +56,8 @@
 
 #define SIG_STACK_SIZE 0x100000
 
-int verbose;                /**< enable verbose mode? */
-int repeat_count = 9;       /**< number of times to exercise the signal handler */
+int verbose = 1;                /**< enable verbose mode? */
+int repeat_count = 1;       /**< number of times to exercise the signal handler */
 int num_errors = 0;         /**< cumulatiove error count */
 
 /* These variables are global because they
@@ -344,6 +344,7 @@ sighandler (int signal, siginfo_t *siginfo UNUSED, void *context)
 int
 main (int argc, char **argv UNUSED)
 {
+  printf(" --------------- run baby run\n");
   struct sigaction act;
 #ifdef HAVE_SIGALTSTACK
   stack_t stk;


### PR DESCRIPTION
On an aarch64 system tdep_trace was returning `-UNW_ESTOPUNWIND` a lot while profiling a Qt 6 / QML application with heaptrack. I have not understood why exactly, but note that QML injects JIT frames and more, which potentially lead to such failures?

Without the patch here, unwinding became excessively slow because the `slow_backtrace` fallback continuously called `tdep_get_elf_image` which is extremely slow for applications with many entries in their `/proc/<pid>/maps` file.

With the patch here applied, I could use heaptrack again with the expected bearable overhead. The backtraces still look fine, so for me this patch here looks like a good workaround.